### PR TITLE
code review of dialogue and log

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -27860,7 +27860,7 @@
 /* 277 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var __WEBPACK_AMD_DEFINE_RESULT__;/*!
+	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/*!
 	  Copyright (c) 2015 Jed Watson.
 	  Licensed under the MIT License (MIT), see
 	  http://jedwatson.github.io/classnames
@@ -27901,9 +27901,9 @@
 			module.exports = classNames;
 		} else if (true) {
 			// register as 'classnames', consistent with npm package name
-			!(__WEBPACK_AMD_DEFINE_RESULT__ = function () {
+			!(__WEBPACK_AMD_DEFINE_ARRAY__ = [], __WEBPACK_AMD_DEFINE_RESULT__ = function () {
 				return classNames;
-			}.call(exports, __webpack_require__, exports, module), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+			}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 		} else {
 			window.classNames = classNames;
 		}
@@ -34583,7 +34583,8 @@
 	  }
 
 	  component._values[propName] = value;
-	  component.forceUpdate();
+
+	  if (component.isMounted()) component.forceUpdate();
 	}
 
 	exports['default'] = _createUncontrollable2['default']([mixin], set);
@@ -43318,7 +43319,7 @@
 	var Log = React.createClass({
 		displayName: "Log",
 		propTypes: {
-			name: proptypes.string.isRequired,
+			playername: proptypes.string.isRequired,
 			messages: proptypes.array.isRequired
 		},
 		componentDidMount: function componentDidMount() {
@@ -43332,12 +43333,14 @@
 		render: function render() {
 			var _this = this;
 
-			var lines = [];
-
-			this.props.messages.forEach((function (message, id) {
-				lines.push(React.createElement(Dialogue, { speaker: message.speaker, line: message.line, key: id }));
-			}).bind(this));
-
+			var lines = this.props.messages.map(function (message, id) {
+				return React.createElement(Dialogue, {
+					speaker: message.speaker,
+					line: message.line,
+					key: id,
+					playername: _this.props.playername
+				});
+			});
 			return React.createElement(
 				Panel,
 				{ className: "log-box", ref: function ref(_ref) {
@@ -43353,7 +43356,7 @@
 	});
 
 	var mapStateToProps = function mapStateToProps(state) {
-		return { name: state.player.name, messages: state.log.messages };
+		return { playername: state.player.name, messages: state.log.messages };
 	};
 
 	module.exports = ReactRedux.connect(mapStateToProps)(Log);
@@ -43364,63 +43367,55 @@
 
 	"use strict";
 
+	// This component displays a single line in the game log window. Used in `log.js`.
+
 	var React = __webpack_require__(1),
-	    ReactRedux = __webpack_require__(209),
 	    proptypes = React.PropTypes,
 	    Row = __webpack_require__(241).Row,
 	    Col = __webpack_require__(241).Col;
 
-	var Dialogue = React.createClass({
-		displayName: "Dialogue",
-		propTypes: {
-			speaker: proptypes.string.isRequired,
-			line: proptypes.array.isRequired,
-			name: proptypes.string.isRequired
-		},
-		render: function render() {
-			var name = this.props.speaker + ":";
-			if (name === "Player:") {
-				name = this.props.name + ":";
-			} else if (name === "Narrator:") {
-				name = "";
-			}
+	var Dialogue = function Dialogue(props) {
 
-			var line = [];
+		// Figure out what name to display, if any
+		var displayname = props.speaker === "Player" ? props.playername + ": " : props.speaker === "Narrator" ? "" : props.speaker + ": ";
 
-			this.props.line.forEach((function (part, id) {
-				line.push(React.createElement(
-					"span",
-					{ key: id, className: part.className },
-					part.text
-				));
-			}).bind(this));
-
+		// Build the line out of the provided parts in order to allow for word-specific styling
+		var line = props.line.map(function (part, id) {
 			return React.createElement(
-				Row,
-				{ className: this.props.speaker },
-				React.createElement(
-					Col,
-					{ xs: 4, md: 1 },
-					name
-				),
-				React.createElement(
-					Col,
-					{ xs: 12, md: 11 },
-					React.createElement(
-						"p",
-						null,
-						line
-					)
-				)
+				"span",
+				{ key: id, className: part.className },
+				part.text
 			);
-		}
-	});
+		});
 
-	var mapStateToProps = function mapStateToProps(state) {
-		return { name: state.player.name };
+		// Return a row with displayname and the built line
+		return React.createElement(
+			Row,
+			{ className: props.speaker },
+			React.createElement(
+				Col,
+				{ xs: 4, md: 1 },
+				displayname
+			),
+			React.createElement(
+				Col,
+				{ xs: 12, md: 11 },
+				React.createElement(
+					"p",
+					null,
+					line
+				)
+			)
+		);
 	};
 
-	module.exports = ReactRedux.connect(mapStateToProps)(Dialogue);
+	Dialogue.propTypes = {
+		speaker: proptypes.string.isRequired,
+		line: proptypes.array.isRequired,
+		playername: proptypes.string.isRequired
+	};
+
+	module.exports = Dialogue;
 
 /***/ },
 /* 488 */

--- a/src/components/dialogue.js
+++ b/src/components/dialogue.js
@@ -1,45 +1,36 @@
-var React = require("react"),
-	ReactRedux = require("react-redux"),
+// This component displays a single line in the game log window. Used in `log.js`.
+
+let React = require("react"),
 	proptypes = React.PropTypes,
 	Row = require("react-bootstrap").Row,
 	Col = require("react-bootstrap").Col;
 
-var Dialogue = React.createClass({
-	displayName: "Dialogue",
-	propTypes: {
-		speaker: proptypes.string.isRequired,
-		line: proptypes.array.isRequired,
-		name: proptypes.string.isRequired
-	},
-	render: function() {
-		var name = this.props.speaker + ":";
-		if (name === "Player:") {
-			name = this.props.name + ":";
-		} else if (name === "Narrator:") {
-			name = "";
-		}
+let Dialogue = (props)=> {
 
-		var line = [];
+	// Figure out what name to display, if any
+	let displayname = 
+		props.speaker === "Player" ? props.playername + ": "
+		: props.speaker === "Narrator" ? ""
+		: props.speaker + ": ";
 
-		this.props.line.forEach(function(part, id) {
-			line.push(<span key={id} className={part.className}>{part.text}</span>);
-		}.bind(this));
+	// Build the line out of the provided parts in order to allow for word-specific styling
+	let line = props.line.map(
+		(part,id)=> <span key={id} className={part.className}>{part.text}</span>
+	);
 
-		return (
-			<Row className={this.props.speaker}>
-				<Col xs={4} md={1}>
-					{name}
-				</Col>
-				<Col xs={12} md={11}>
-					<p>{line}</p>
-				</Col>
-			</Row>
-		);
-	}
-});
-
-var mapStateToProps = function (state) {
-	return { name: state.player.name };
+	// Return a row with displayname and the built line
+	return (
+		<Row className={props.speaker}>
+			<Col xs={4} md={1}>{displayname}</Col>
+			<Col xs={12} md={11}><p>{line}</p></Col>
+		</Row>
+	);
 };
 
-module.exports = ReactRedux.connect(mapStateToProps)(Dialogue);
+Dialogue.propTypes = {
+	speaker: proptypes.string.isRequired,
+	line: proptypes.array.isRequired,
+	playername: proptypes.string.isRequired
+};
+
+module.exports = Dialogue;

--- a/src/components/log.js
+++ b/src/components/log.js
@@ -1,4 +1,4 @@
-var React = require("react"),
+let React = require("react"),
 	ReactDOM = require("react-dom"),
 	ReactRedux = require("react-redux"),
 	proptypes = React.PropTypes,
@@ -8,27 +8,27 @@ var React = require("react"),
 	Col = require("react-bootstrap").Col,
 	Dialogue = require("./dialogue");
 
-var Log = React.createClass({
+let Log = React.createClass({
 	displayName: "Log",
 	propTypes: {
-		name: proptypes.string.isRequired,
+		playername: proptypes.string.isRequired,
 		messages: proptypes.array.isRequired
 	},
-	componentDidMount: function() {
- 		var node = ReactDOM.findDOMNode(this.logpanel);
+	componentDidMount() {
+ 		let node = ReactDOM.findDOMNode(this.logpanel);
 		node.scrollTop = node.scrollHeight;
 	},
-	componentDidUpdate: function() {
- 		var node = ReactDOM.findDOMNode(this.logpanel);
+	componentDidUpdate() {
+ 		let node = ReactDOM.findDOMNode(this.logpanel);
 		node.scrollTop = node.scrollHeight;
 	},
-	render: function() {
-		var lines = [];
-
-		this.props.messages.forEach(function(message, id) {
-			lines.push(<Dialogue speaker={message.speaker} line={message.line} key={id} />);
-		}.bind(this));
-
+	render() {
+		let lines = this.props.messages.map((message, id)=> <Dialogue
+			speaker={message.speaker}
+			line={message.line}
+			key={id}
+			playername={this.props.playername}
+		/>);
 		return (
 			<Panel className="log-box" ref={(ref) => this.logpanel = ref} >
 				<Grid fluid>
@@ -39,8 +39,8 @@ var Log = React.createClass({
 	}
 });
 
-var mapStateToProps = function (state) {
-	return { name: state.player.name, messages: state.log.messages };
+let mapStateToProps = (state)=> {
+	return { playername: state.player.name, messages: state.log.messages };
 };
 
 module.exports = ReactRedux.connect(mapStateToProps)(Log);


### PR DESCRIPTION
Ooops, sorry, should've left `bundle.js` out! Anyway. :)

This PR does a short code review of `Log` and `Dialogue`, just to put you on track regarding...
-    some ES2015 syntax such as succinct methods, arrow functions and `let`
-    using `map` instead of pushing in a `forEach`
-    the stateless component syntax introduced in React 0.14
-    dumb children (`Dialogue` doesn't need to also be aware of Redux, simply provide the `playername` from `Log`)
